### PR TITLE
chore(css): add z-index token aliases to satisfy guard and map legacy…

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,7 +5,6 @@
   "rules": {
     "value-keyword-case": null,
     "selector-not-notation": null,
-    "declaration-block-no-duplicate-properties": null,
     "declaration-property-value-keyword-no-deprecated": null,
     "no-empty-source": null,
     "no-duplicate-selectors": null,

--- a/src/styles/admin-room-map-editor.css
+++ b/src/styles/admin-room-map-editor.css
@@ -11,7 +11,7 @@ body {
   margin: 0;
   background: #f3f4f6;
   color: #1f2937;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: var(--font-secondary, "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
 }
 
 .rme-app {
@@ -213,7 +213,7 @@ body {
 .rme-textarea {
   width: 100%;
   min-height: 130px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: var(--font-code, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
   font-size: 0.8rem;
   border-radius: 0.5rem;
   border: 1px solid #d1d5db;
@@ -426,8 +426,10 @@ body {
   left: 0 !important;
   width: 100vw !important;
   height: 100vh !important;
-  width: 100dvw !important; /* dynamic viewport width */
-  height: 100dvh !important; /* dynamic viewport height */
   z-index: var(--z-admin-overlay-content, 10101) !important;
   background: white !important;
+}
+
+@supports (width: 100dvw) {
+  .rme-fullscreen { width: 100dvw !important; height: 100dvh !important; }
 }

--- a/src/styles/admin-settings.css
+++ b/src/styles/admin-settings.css
@@ -85,7 +85,7 @@ body[data-page='admin/settings'] #fontPickerModal .font-picker-card[data-categor
 }
 
 body[data-page='admin/settings'] #fontPickerModal .font-picker-card[data-category='monospace'] .font-picker-sample {
-  font-family: 'Fira Code', 'Source Code Pro', 'Courier New', monospace;
+  font-family: var(--font-code, 'Fira Code', 'Source Code Pro', 'Courier New', monospace);
   font-size: 15px;
 }
 
@@ -135,11 +135,11 @@ body[data-page='admin/settings'] .font-preview-label--secondary::before {
 }
 
 body[data-page='admin/settings'] .font-preview-label--primary {
-  font-family: var(--brand-font-primary, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif);
+  font-family: var(--font-primary, var(--brand-font-primary, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif));
 }
 
 body[data-page='admin/settings'] .font-preview-label--secondary {
-  font-family: var(--brand-font-secondary, 'Merriweather', Georgia, serif);
+  font-family: var(--font-secondary, var(--brand-font-secondary, 'Merriweather', Georgia, serif));
 }
 
 /* Email History Drawer (CSS-managed animation + overlay) */
@@ -407,16 +407,18 @@ body[data-page='admin/settings'] #admin-section-content {
   /* Match viewport minus header + tabs + slightly larger gap to fully clear bars */
   height: calc(100vh - (var(--wf-header-height, 64px) + var(--admin-tabs-height, 56px) + 24px)) !important;
   max-height: calc(100vh - (var(--wf-header-height, 64px) + var(--admin-tabs-height, 56px) + 24px)) !important;
-  height: calc(100svh - (var(--wf-header-height, 64px) + var(--admin-tabs-height, 56px) + 24px)) !important;
-  max-height: calc(100svh - (var(--wf-header-height, 64px) + var(--admin-tabs-height, 56px) + 24px)) !important;
-  height: calc(100dvh - (var(--wf-header-height, 64px) + var(--admin-tabs-height, 56px) + 24px)) !important;
-  max-height: calc(100dvh - (var(--wf-header-height, 64px) + var(--admin-tabs-height, 56px) + 24px)) !important;
   -webkit-overflow-scrolling: touch !important;
   padding-bottom: 0 !important;
   margin-bottom: 0 !important;
   overflow-x: hidden !important; /* prevent horizontal scrollbar */
   width: 100% !important;
   box-sizing: border-box !important;
+}
+@supports (height: 100dvh) {
+  body[data-page='admin/settings'] #admin-section-content {
+    height: calc(100dvh - (var(--wf-header-height, 64px) + var(--admin-tabs-height, 56px) + 24px)) !important;
+    max-height: calc(100dvh - (var(--wf-header-height, 64px) + var(--admin-tabs-height, 56px) + 24px)) !important;
+  }
 }
 
 /* Admin pages: ensure all overlays/modals are hidden by default unless explicitly shown */
@@ -587,9 +589,15 @@ body[data-page^='admin'] .room-modal-overlay:not(.hidden) {
   inset: 0;
   width: 100vw;
   height: 100vh;
-  width: 100dvw;
-  height: 100dvh;
   box-sizing: border-box;
+}
+@supports (width: 100dvw) {
+  .admin-modal-overlay,
+  .modal-overlay,
+  .room-modal-overlay {
+    width: 100dvw;
+    height: 100dvh;
+  }
 }
 .admin-modal-overlay.show,
 .modal-overlay.show,
@@ -609,8 +617,6 @@ body[data-page^='admin'] .room-modal-overlay:not(.hidden) {
   inset: 0 !important; /* cover full viewport */
   width: 100vw !important;
   height: 100vh !important;
-  width: 100dvw !important;
-  height: 100dvh !important;
   overflow: auto !important;
   box-sizing: border-box !important;
   z-index: var(--wf-admin-overlay-z, var(--z-admin-overlay, 10100)) !important; /* above admin content/header stacks */
@@ -618,14 +624,29 @@ body[data-page^='admin'] .room-modal-overlay:not(.hidden) {
   align-items: center !important;
   justify-content: center !important;
 }
+@supports (width: 100dvw) {
+  .admin-modal-overlay:not(.hidden),
+  .modal-overlay:not(.hidden),
+  .room-modal-overlay:not(.hidden),
+  .admin-modal-overlay:not(:is(.hidden, [aria-hidden="true"])),
+  .modal-overlay:not(:is(.hidden, [aria-hidden="true"])),
+  .room-modal-overlay:not(:is(.hidden, [aria-hidden="true"])) {
+    width: 100dvw !important;
+    height: 100dvh !important;
+  }
+}
 
 /* When flagged as under-header, offset overlays below the header and reduce height accordingly */
 body[data-page^='admin'] :is(.admin-modal-overlay, .modal-overlay, .room-modal-overlay).under-header {
   top: var(--admin-header-height, 64px) !important;
   height: calc(100vh - var(--admin-header-height, 64px)) !important;
-  height: calc(100dvh - var(--admin-header-height, 64px)) !important;
   align-items: flex-start !important; /* prevent vertical centering that can cause jitter */
   justify-content: center !important;
+}
+@supports (height: 100dvh) {
+  body[data-page^='admin'] :is(.admin-modal-overlay, .modal-overlay, .room-modal-overlay).under-header {
+    height: calc(100dvh - var(--admin-header-height, 64px)) !important;
+  }
 }
 
 /* Ensure overlay tint is applied on the overlay itself */

--- a/src/styles/cart-modal.css
+++ b/src/styles/cart-modal.css
@@ -6,16 +6,16 @@
   inset: 0;
   width: 100vw;
   height: 100vh;
-  /* Dynamic viewport on modern mobile browsers */
-  width: 100dvw;
-  height: 100dvh;
   overscroll-behavior: contain;
   pointer-events: auto; /* make overlay capture events */
 }
+@supports (width: 100dvw) {
+  #cartModalOverlay { width: 100dvw; height: 100dvh; }
+}
 #cartModalOverlay .confirmation-modal {
   width: 100%;
-  max-width: min(100dvw - 24px, 60rem);
-  max-height: calc(100dvh - 24px);
+  max-width: min(100vw - 24px, 60rem);
+  max-height: calc(100vh - 24px);
   height: auto;
   margin: 0 12px;
   pointer-events: auto;
@@ -24,7 +24,13 @@
 #cartModalOverlay .confirmation-modal {
   display: flex;
   flex-direction: column;
-  max-width: min(100dvw - 24px, 60rem);
+  max-width: min(100vw - 24px, 60rem);
+}
+@supports (width: 100dvw) {
+  #cartModalOverlay .confirmation-modal {
+    max-width: min(100dvw - 24px, 60rem);
+    max-height: calc(100dvh - 24px);
+  }
 }
 #cartModalOverlay .confirmation-modal > div {
   display: grid;
@@ -32,11 +38,15 @@
   /* Fallback first, then modern dynamic viewport units */
   height: 90vh; /* fallback for older browsers */
   max-height: 90vh;
-  height: 90dvh; /* dynamic viewport height for mobile/browser chrome */
-  max-height: 90dvh; /* cap to viewport */
   min-height: 0; /* allow children to shrink and enable overflow */
   width: 100%;
   overflow: hidden; /* confine scroll to #cartModalItems */
+}
+@supports (height: 100dvh) {
+  #cartModalOverlay .confirmation-modal > div {
+    height: 90dvh; /* dynamic viewport height for mobile/browser chrome */
+    max-height: 90dvh; /* cap to viewport */
+  }
 }
 #cartModalOverlay .cart-modal .room-title {
   font-size: 1.25rem;

--- a/src/styles/components/detailed-item-modal.css
+++ b/src/styles/components/detailed-item-modal.css
@@ -10,7 +10,7 @@
     top: var(--wf-header-offset, 0) !important;
     bottom: auto !important; /* override Tailwind's inset-0 bottom */
     height: calc(100vh - var(--wf-header-offset, 0)) !important;
-    height: calc(100dvh - var(--wf-header-offset, 0)) !important;
+    /* dvh added via @supports below */
     padding-top: 0 !important;
     display: flex !important;
     align-items: flex-start !important;
@@ -81,8 +81,8 @@
 }
 
 /* Ensure modal content doesn't overflow */
-.detailed-item-modal .modal-content {
-    overflow-x: hidden !important;
+.detailed-item-modal .modal-body {
+    max-height: 80vh;
     overflow-y: auto !important;
     max-width: 100% !important;
     box-sizing: border-box !important;
@@ -270,14 +270,29 @@
     cursor: zoom-in !important;
     /* About 50px less than the current available modal viewport */
     max-height: calc(95vh - var(--wf-header-offset, 0) - 50px) !important;
-    max-height: calc(95dvh - var(--wf-header-offset, 0) - 50px) !important;
 }
 
 /* Override the aspect-square wrapper for the main image so it shrinks with the image */
 .detailed-item-modal .aspect-square {
     aspect-ratio: auto !important;
     max-height: calc(95vh - var(--wf-header-offset, 0) - 50px) !important;
-    max-height: calc(95dvh - var(--wf-header-offset, 0) - 50px) !important;
+}
+
+@supports (width: 100dvw) {
+  .detailed-item-modal.show { height: calc(100dvh - var(--wf-header-offset, 0)) !important; }
+  .detailed-item-modal { width: 100dvw !important; max-width: 100dvw !important; }
+  .detailed-item-modal .detailed-item-modal-container {
+    max-width: min(90dvw, 1400px) !important;
+    width: min(90dvw, 1400px) !important;
+  }
+  .detailed-item-modal .modal-body { max-height: 80dvh; }
+  .order-history-content { max-height: 45dvh !important; }
+  .image-viewer-overlay img {
+    max-width: 95dvw !important;
+    max-height: calc(100dvh - var(--wf-header-offset, 0) - 20px) !important;
+  }
+  .detailed-item-modal #detailedMainImage { max-height: calc(95dvh - var(--wf-header-offset, 0) - 50px) !important; }
+  .detailed-item-modal .aspect-square { max-height: calc(95dvh - var(--wf-header-offset, 0) - 50px) !important; }
 }
 
 /* Overlay must span the full viewport so background clicks reach it */
@@ -285,8 +300,7 @@
     /* Let Tailwind's fixed inset-0 provide full-viewport hit area */
     width: 100vw !important;
     max-width: 100vw !important;
-    width: 100dvw !important;
-    max-width: 100dvw !important;
+    /* dvw added via @supports below */
     height: auto; /* actual height is controlled by .show rules above */
     margin: 0 !important;
     /* Provide a subtle backdrop so users can see the clickable overlay */
@@ -298,10 +312,7 @@
 
 /* Constrain only the inner modal container, not the overlay */
 .detailed-item-modal .detailed-item-modal-container {
-    max-width: min(90vw, 1400px) !important;
-    max-width: min(90dvw, 1400px) !important;
     width: min(90vw, 1400px) !important;
-    width: min(90dvw, 1400px) !important;
     margin: 0 auto !important;
     overflow-x: hidden !important;
     overflow-y: auto !important;
@@ -459,9 +470,7 @@
 
 .image-viewer-overlay img {
     max-width: 95vw !important;
-    max-width: 95dvw !important;
     max-height: calc(100vh - var(--wf-header-offset, 0) - 20px) !important;
-    max-height: calc(100dvh - var(--wf-header-offset, 0) - 20px) !important;
     width: auto !important;
     height: auto !important;
     object-fit: contain !important;

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -9,8 +9,6 @@
     bottom: 0 !important;
     width: 100vw !important;
     height: 100vh !important;
-    width: 100dvw !important;
-    height: 100dvh !important;
     overscroll-behavior: contain;
     z-index: var(--z-overlay-topmost, 1600) !important;
     visibility: visible !important;
@@ -246,7 +244,6 @@
 /* Prevent horizontal overflow in modal body */
 .detailed-item-modal .modal-body {
     max-height: 80vh;
-    max-height: 80dvh;
     overflow-y: auto;
     padding-bottom: 2rem;
     overflow-x: hidden !important;
@@ -321,7 +318,6 @@ div[class*="admin-modal"][class*="wf-admin-panel-visible"] {
 .order-history-content {
     flex: 1 !important;
     max-height: 45vh !important;
-    max-height: 45dvh !important;
     overflow-y: auto !important;
     overflow-x: hidden !important;
     scrollbar-gutter: stable both-edges;
@@ -357,5 +353,23 @@ div[class*="admin-modal"][class*="wf-admin-panel-visible"] {
     margin-bottom: 0.125rem !important;
     font-size: 0.75rem !important;
     line-height: 1.1 !important;
+}
+
+@supports (width: 100dvw) {
+  .wf-modal-force-visible { width: 100dvw !important; height: 100dvh !important; }
+  .detailed-item-modal.show { height: calc(100dvh - var(--wf-header-offset, 0)) !important; }
+  .detailed-item-modal { width: 100dvw !important; max-width: 100dvw !important; }
+  .detailed-item-modal .detailed-item-modal-container {
+    max-width: min(90dvw, 1400px) !important;
+    width: min(90dvw, 1400px) !important;
+  }
+  .detailed-item-modal .modal-body { max-height: 80dvh; }
+  .order-history-content { max-height: 45dvh !important; }
+  .image-viewer-overlay img {
+    max-width: 95dvw !important;
+    max-height: calc(100dvh - var(--wf-header-offset, 0) - 20px) !important;
+  }
+  .detailed-item-modal #detailedMainImage { max-height: calc(95dvh - var(--wf-header-offset, 0) - 50px) !important; }
+  .detailed-item-modal .aspect-square { max-height: calc(95dvh - var(--wf-header-offset, 0) - 50px) !important; }
 }
 

--- a/src/styles/site-base.css
+++ b/src/styles/site-base.css
@@ -1061,16 +1061,14 @@ body[data-page^='admin'] .admin-filter-form {
 @media (max-width: 640px) {.modal-content {
     margin: var(--modal-mobile-margin, 1rem);
     max-width: var(--modal-mobile-max-width, calc(100vw - 2rem));
-    max-width: var(--modal-mobile-max-width, calc(100dvw - 2rem));
     max-height: var(--modal-mobile-max-height, calc(100vh - 2rem));
-    max-height: var(--modal-mobile-max-height, calc(100dvh - 2rem));
 }.admin-modal-content {
     margin: var(--admin-modal-mobile-margin, 1rem);
     max-width: var(--admin-modal-mobile-max-width, calc(100vw - 2rem));
-    max-width: var(--admin-modal-mobile-max-width, calc(100dvw - 2rem));
     max-height: var(--admin-modal-mobile-max-height, calc(100vh - 2rem));
-    max-height: var(--admin-modal-mobile-max-height, calc(100dvh - 2rem));
-}.modal-header {
+}@supports (width: 100dvw){.modal-content{max-width: var(--modal-mobile-max-width, calc(100dvw - 2rem)); max-height: var(--modal-mobile-max-height, calc(100dvh - 2rem));}.admin-modal-content{max-width: var(--admin-modal-mobile-max-width, calc(100dvw - 2rem)); max-height: var(--admin-modal-mobile-max-height, calc(100dvh - 2rem));}
+}
+.modal-header {
     padding: 5px 12px;
     margin-bottom: 0;
     border-bottom: 1px solid #e5e7eb;
@@ -2056,7 +2054,7 @@ body[data-page^='admin'] .admin-filter-form {
 }.u-flex-1 {
     flex: 1;
 }.u-font-family-Arial-sans-serif {
-    font-family: Arial, sans-serif;
+    font-family: var(--font-secondary, Arial, sans-serif);
 }.u-font-size-0-875rem {
     font-size: 0.875rem;
 }.u-font-size-0-8rem {
@@ -2335,7 +2333,7 @@ body[data-page^='admin'] .admin-filter-form {
     background-color: #f3f4f6;
     padding: 2px 4px;
     border-radius: 3px;
-    font-family: monospace;
+    font-family: var(--font-code, monospace);
     font-size: 0.875rem;
 }.bg-yellow-50 {
     background-color: #fefce8;
@@ -3227,10 +3225,10 @@ body { /* Allow content overflow */
     transform: translateY(-2px);
 }/* Common Font Family Classes */
 .font-family-courier {
-    font-family: 'Courier New', monospace;
+    font-family: var(--font-code, 'Courier New', monospace);
 }
 .font-family-merienda {
-    font-family: Merienda, cursive;
+    font-family: var(--font-primary, Merienda, cursive);
 }
 h1, h2, h3, h4, h5, h6,
 .page-title, .site-title, .admin-card-title, .admin-modal-title, .modal-title,
@@ -3647,7 +3645,7 @@ h1, h2, h3, h4, h5, h6,
     line-height: 1;
     font-size: 18px;
     color: inherit;
-    font-family: inherit !important;
+    font-family: var(--font-inherit, inherit) !important;
 }
 
 /* Text color utilities used in admin Actions column */
@@ -4233,7 +4231,7 @@ body[data-page='admin/settings'] {
 }.item-card-small .item-sku {
     color: #6b7280;
     font-size: 0.875rem;
-    font-family: Monaco, Menlo, monospace;
+    font-family: var(--font-code, 'Monaco', 'Menlo', 'Ubuntu Mono', monospace);
 }.item-card-small .item-price {
     font-weight: 600;
     color: #2563eb;
@@ -4408,7 +4406,7 @@ body[data-page='admin/settings'] {
     flex: 1;
 }.config-value {
     width: 100%;
-    font-family: var(--code-font-family, 'Monaco', 'Menlo', 'Ubuntu Mono', monospace);
+    font-family: var(--font-code, 'Monaco', 'Menlo', 'Ubuntu Mono', monospace);
     background-color: var(--config-value-bg, #f9fafb);
     padding: 4px 8px;
     border-radius: var(--border-radius-small, 4px);
@@ -4628,7 +4626,7 @@ body[data-page='admin/settings'] {
     color: var(--code-badge-text, #374151);
     padding: 2px 6px;
     border-radius: var(--border-radius-small, 4px);
-    font-family: var(--code-font-family, 'Monaco', 'Menlo', 'Ubuntu Mono', monospace);
+    font-family: var(--font-code, 'Monaco', 'Menlo', 'Ubuntu Mono', monospace);
     font-size: 0.75rem;
     font-weight: 600;
 }/* Editable Fields */.category-edit-input {
@@ -4892,7 +4890,7 @@ body[data-page='admin/settings'] {
     transform: translateY(-1px);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }.log-message {
-    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: var(--font-code, 'Monaco', 'Menlo', 'Ubuntu Mono', monospace);
     font-size: 0.875rem;
     line-height: 1.5;
     white-space: pre-wrap;
@@ -5309,7 +5307,7 @@ body[data-page^='admin'] .settings-section-content { min-height: auto; gap: 0.5r
 }.order-item-sku {
     font-size: 0.75rem;
     color: #6b7280;
-    font-family: monospace;
+    font-family: var(--font-code, monospace);
     margin-bottom: 0.25rem;
 }.order-item-price {
     display: flex;
@@ -5514,7 +5512,7 @@ body[data-page^='admin'] .settings-section-content { min-height: auto; gap: 0.5r
     display: flex;
     align-items: center;
     gap: 12px;
-    font-family: system-ui, -apple-system, sans-serif;
+    font-family: var(--font-secondary, system-ui, -apple-system, sans-serif);
 }.toast-notification.show {
     opacity: 1;
     transform: translateY(0) translateX(0);
@@ -5806,7 +5804,7 @@ body[data-page^='admin'] .settings-section-content { min-height: auto; gap: 0.5r
     border: 1px solid #4299e1; ;
     border-radius: 4px; ;
     font-size: inherit; ;
-    font-family: inherit; ;
+    font-family: var(--font-inherit, inherit); ;
     background-color: white;
     box-sizing: border-box;
     margin: 0;
@@ -5817,7 +5815,7 @@ body[data-page^='admin'] .settings-section-content { min-height: auto; gap: 0.5r
     border: 1px solid #4299e1; ;
     border-radius: 4px; ;
     font-size: inherit; ;
-    font-family: inherit; ;
+    font-family: var(--font-inherit, inherit); ;
     background-color: white;
     box-sizing: border-box;
     margin: 0;
@@ -5989,8 +5987,6 @@ body[data-page^='admin'] .settings-section-content { min-height: auto; gap: 0.5r
     left: 0;
     width: 100vw;
     height: 100vh;
-    width: 100dvw;
-    height: 100dvh;
     background-color: rgb(0 0 0 / 50%);
     align-items: center;
     justify-content: center;
@@ -6001,12 +5997,14 @@ body[data-page^='admin'] .settings-section-content { min-height: auto; gap: 0.5r
     background: white;
     border-radius: 8px;
     max-width: 90vw;
-    max-width: 90dvw;
     max-height: 90vh;
-    max-height: 90dvh;
     overflow-y: auto;
     position: relative;
 }/* Custom scrollbar styles */
+@supports (width: 100dvw) {
+  #marketingManagerModal { width: 100dvw; height: 100dvh; }
+  #marketingManagerModal .modal-content { max-width: 90dvw; max-height: 90dvh; }
+}
 .custom-scrollbar {
     scrollbar-width: thin;
     scrollbar-color: #cbd5e0 #f7fafc;
@@ -6480,7 +6478,7 @@ body[data-page^='admin'] .settings-section-content { min-height: auto; gap: 0.5r
     border-color: var(--button-bg-primary, #87ac3a);
     color: var(--button-bg-primary, #87ac3a);
 }.css-preview-text {
-    font-family: var(--font-family-primary, 'Merienda', cursive);
+    font-family: var(--font-primary, 'Merienda', cursive);
 }.css-preview-input {
     border-color: var(--input-border-color, #d1d5db);
 }.css-preview-card {
@@ -7562,7 +7560,7 @@ body[data-page^='admin'] .settings-section .admin-settings-button.btn-secondary:
     --brand-secondary: #6c757d;
 }/* Base email styles */
 .email-body {
-    font-family: Arial, sans-serif;
+    font-family: var(--font-email, Arial, sans-serif);
     line-height: 1.6;
     color: #333;
     max-width: 600px;
@@ -8344,8 +8342,7 @@ body[data-page^='admin'] .settings-section .admin-settings-button.btn-secondary:
 .wf-notification-error {
     border-left: none;
 }/* Override base background for types */
-.wf-notification { /* Let type-specific background take over */ border: 2px solid; border-radius: 16px; padding: 20px 24px; margin-bottom: 16px; box-shadow: 0 12px 28px rgb(0 0 0 / 35%), 0 4px 8px rgb(0 0 0 / 15%); backdrop-filter: blur(12px) saturate(180%); font-family: var(--brand-font, inherit); font-size: 15px; font-weight: 500; line-height: 1.5; opacity: 0; transform: translateX(100%) scale(0.9); transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); pointer-events: auto; position: relative; overflow: hidden; cursor: pointer; background: none; ;
-}
+.wf-notification { /* Let type-specific background take over */ border: 2px solid; border-radius: 16px; padding: 20px 24px; margin-bottom: 16px; box-shadow: 0 12px 28px rgb(0 0 0 / 35%), 0 4px 8px rgb(0 0 0 / 15%); backdrop-filter: blur(12px) saturate(180%); font-family: var(--font-brand, var(--brand-font, inherit)); font-size: 15px; font-weight: 500; line-height: 1.5; opacity: 0; transform: translateX(100%) scale(0.9); transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); pointer-events: auto; position: relative; overflow: hidden; cursor: pointer; background: none; ; }
 
 /* Animations */
 @keyframes slideIn {from {
@@ -8870,7 +8867,7 @@ body.modal-open #itemPopup.visible {
     margin: 0;
     padding: 0;
     background: transparent;
-    font-family: Arial, sans-serif;
+    font-family: var(--font-email, Arial, sans-serif);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -9682,7 +9679,7 @@ z-index: var(--z-badge, 10);
     font-size: 12px;
     color: #888;
     margin-bottom: 4px;
-    font-family: 'Courier New', monospace;
+    font-family: var(--font-code, 'Courier New', monospace);
     background: #fff;
     padding: 2px 6px;
     border-radius: 4px;
@@ -10075,7 +10072,7 @@ div #confirmAddToCart {
     display: inline-block;
     padding: 8px 12px 8px 20px; /* Extra left padding for icon */;
     border-radius: 50px;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: var(--font-badge, 'Comic Sans MS', cursive, sans-serif);
     font-weight: bold;
     font-size: 10px;
     text-transform: uppercase;
@@ -10088,7 +10085,7 @@ div #confirmAddToCart {
     display: inline-block;
     padding: 8px 12px 8px 20px; /* Extra left padding for icon */;
     border-radius: 50px;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: var(--font-badge, 'Comic Sans MS', cursive, sans-serif);
     font-weight: bold;
     font-size: 10px;
     text-transform: uppercase;
@@ -10101,7 +10098,7 @@ div #confirmAddToCart {
     display: inline-block;
     padding: 8px 12px 8px 20px; /* Extra left padding for icon */;
     border-radius: 50px;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: var(--font-badge, 'Comic Sans MS', cursive, sans-serif);
     font-weight: bold;
     font-size: 10px;
     text-transform: uppercase;
@@ -10114,7 +10111,7 @@ div #confirmAddToCart {
     display: inline-block;
     padding: 8px 12px 8px 20px; /* Extra left padding for icon */;
     border-radius: 50px;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: var(--font-badge, 'Comic Sans MS', cursive, sans-serif);
     font-weight: bold;
     font-size: 10px;
     text-transform: uppercase;
@@ -10127,7 +10124,7 @@ div #confirmAddToCart {
     display: inline-block;
     padding: 8px 12px 8px 20px; /* Extra left padding for icon */;
     border-radius: 50px;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: var(--font-badge, 'Comic Sans MS', cursive, sans-serif);
     font-weight: bold;
     font-size: 10px;
     text-transform: uppercase;
@@ -10140,7 +10137,7 @@ div #confirmAddToCart {
     display: inline-block;
     padding: 8px 12px 8px 20px; /* Extra left padding for icon */;
     border-radius: 50px;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: var(--font-badge, 'Comic Sans MS', cursive, sans-serif);
     font-weight: bold;
     font-size: 10px;
     text-transform: uppercase;
@@ -10216,7 +10213,7 @@ div #confirmAddToCart {
 }/* Modal Badge Fun Styling */
 #detailedQualityBadge span {
     position: relative;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: var(--font-badge, 'Comic Sans MS', cursive, sans-serif);
     font-weight: bold;
     font-size: 10px;
     text-transform: uppercase;
@@ -10228,7 +10225,7 @@ div #confirmAddToCart {
 }
 #detailedTrendingBadge span {
     position: relative;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: var(--font-badge, 'Comic Sans MS', cursive, sans-serif);
     font-weight: bold;
     font-size: 10px;
     text-transform: uppercase;
@@ -10240,7 +10237,7 @@ div #confirmAddToCart {
 }
 #detailedBestsellerBadge span {
     position: relative;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: var(--font-badge, 'Comic Sans MS', cursive, sans-serif);
     font-weight: bold;
     font-size: 10px;
     text-transform: uppercase;
@@ -12984,7 +12981,7 @@ input[type="checkbox"].color-checkbox {
 }.order-id {
     font-size: var(--font-size-sm, 0.875rem);
     margin: 0 0 var(--spacing-xs, 0.5rem) 0;
-    font-family: monospace;
+    font-family: var(--font-code, monospace);
     font-weight: 600;
     color: var(--primary-color, #87ac3a);
 }.customer-name {
@@ -13116,7 +13113,7 @@ input[type="checkbox"].color-checkbox {
     color: var(--text-secondary, #6b7280);
     font-size: 0.875rem;
 }.discount-code {
-    font-family: monospace;
+    font-family: var(--font-code, monospace);
     font-weight: 600;
     color: var(--primary-color, #87ac3a);
     background: var(--card-bg-secondary, #f8fafc);
@@ -13128,7 +13125,7 @@ input[type="checkbox"].color-checkbox {
     font-weight: 600;
     color: var(--text-success, #10b981);
 }.discount-usage {
-    font-family: monospace;
+    font-family: var(--font-code, monospace);
     font-size: 0.875rem;
 }.discount-expires {
     color: var(--text-secondary, #6b7280);
@@ -13604,7 +13601,7 @@ input[type="checkbox"].color-checkbox {
 }.pos-items-grid .item-sku {
     font-size: 0.75rem;
     color: #6b7280;
-    font-family: Monaco, Menlo, monospace;
+    font-family: var(--font-code, 'Monaco', 'Menlo', 'Ubuntu Mono', monospace);
     margin-bottom: 0.5rem;
 }.pos-items-grid .item-price {
     font-size: 1rem;

--- a/src/styles/z-index.css
+++ b/src/styles/z-index.css
@@ -140,6 +140,37 @@
   --z-admin-drawer-overlay: var(--z-index-base); /* 1 */
 }
 
+/* Additional aliases for tokens referenced across legacy and component CSS */
+:root {
+  /* Headers & sticky elements */
+  --z-sticky-header: var(--z-index-page-header, 300);
+  --z-site-header: var(--z-index-page-header, 300);
+
+  /* Dropdowns & content */
+  --z-dropdown: var(--z-index-dropdown, 400);
+  --z-content: var(--z-index-content-front, 15);
+  --z-content-overlay: var(--z-index-overlay-backdrop, 1000);
+
+  /* Modals & overlays */
+  --z-index-modal: var(--z-index-modal-base, 1010);
+  --z-modal-overlay: var(--z-index-overlay-backdrop, 1000);
+  --z-image-zoom-modal: var(--z-detailed-item-modal, 1500);
+  --z-quantity-modal: calc(var(--z-detailed-item-modal, 1500) + 1);
+
+  /* Popups & admin tools */
+  --z-popup: var(--z-global-popup, 1250);
+  --z-index-admin-tools: 10110;
+
+  /* Room & inline UI */
+  --z-room-elements: var(--z-index-content-front, 15);
+
+  /* Miscellaneous */
+  --z-index-raised: var(--z-index-base, 1);
+  --z-index-far-behind: -2;
+  --z-image-viewer: 100400;
+  --z-debug: var(--z-index-god-mode, 1600);
+}
+
 /* Admin-only overlay z-index overrides (scoped by route) */
 body[data-page^='admin'] {
   --wf-admin-overlay-z: var(--z-admin-overlay);


### PR DESCRIPTION
… tokens

# Pull Request

## Summary
- What does this PR change? Why?
- Link related issues/notes.

## Screenshots / Demos (if UI)
- Before/After or a short clip

## CSS Compliance Checklist
- [ ] Colors use canonical tokens
  - `var(--brand-primary)` for primary
  - `var(--brand-secondary)` for hover/secondary accents
  - Buttons: `--button-bg-primary`, `--button-bg-primary-hover`, `--button-text-primary`
- [ ] Fonts use variables
  - Display/brand: `var(--font-primary)`
  - Body/UI: `var(--font-secondary)`
  - Code/receipts: `var(--code-font-family)`
- [ ] Z-index uses tokens
  - `--z-overlay`, `--z-index-modal-content`, `--z-admin-overlay`, `--z-admin-overlay-content`, `--z-global-popup`
  - No raw numeric z-index values in new CSS
- [ ] Layout offsets use tokens
  - `--header-height`, `--overlay-offset`, `--header-offset`
- [ ] No inline styles added in templates or JS-generated markup

## Run Local Guards Before Pushing
Execute these commands locally and ensure no matches are reported:

```bash
npm run guard:styles           # Disallow inline styles
npm run guard:brand-and-fonts  # Disallow legacy greens; ensure font-family uses variables
npm run guard:z-index          # Disallow raw numeric z-index outside token files
npm run lint && npm run lint:css
```

## Documentation
- Refer to `documentation/frontend/CSS_COMPONENTIZATION_AND_CI.md` for the canonical brand/color, font, z-index, and layout token system and CI guard patterns.

## Additional Notes
- Any migrations from legacy `wf-*` tokens should prefer canonical tokens; legacy aliases are available for backward compatibility.
