### PR TITLE
Document PR-only main workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+- Explain what changed and why.
+
+## Security Checklist
+
+- [ ] No secrets/private keys are committed.
+- [ ] `Secret Scan / gitleaks` passes.
+- [ ] Branch is up to date with `main`.
+
+## Test Plan
+
+- [ ] Manual verification completed.
+- [ ] Any relevant automated checks pass.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Documentation and legacy code were archived to `backups/cleanup_2025_11_26` on W
 - Keep "Require branches to be up to date before merging" enabled.
 - Do not allow force pushes or branch deletions on `main`.
 
+## PR-Only Main Workflow
+
+- Do not push directly to `main`.
+- Open a pull request from a feature branch and merge only after required checks pass.
+- Keep branch protection configured with:
+  - required pull request reviews
+  - required status check `Secret Scan / gitleaks`
+  - no force-push and no delete on `main`
+


### PR DESCRIPTION
## Summary
- add a PR template with a focused security checklist (`Secret Scan / gitleaks`, no secrets committed, branch up-to-date)
- document a PR-only merge policy in `README.md` so contributors avoid direct pushes to `main`
- align repository process with the enforced branch protection requiring PR reviews and required status checks

## Test plan
- [x] Confirm branch protection on `main` requires at least one PR approval
- [x] Confirm branch protection on `main` requires `Secret Scan / gitleaks`
- [x] Push this branch and verify PR template is available when opening a PR

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds contribution/process guidance; no runtime code paths or data/security logic are modified.
> 
> **Overview**
> Adds a `.github/pull_request_template.md` to standardize PRs with a brief summary section, a security checklist (no secrets, `Secret Scan / gitleaks`, branch up-to-date), and a test plan.
> 
> Updates `README.md` to explicitly document a PR-only policy for `main` and reiterate the required branch protection settings (reviews + `Secret Scan / gitleaks`, no force-push/delete).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96869631d4588557a077996a4852dfd3e0a01496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->